### PR TITLE
Explicitly sort filesystem iteration results

### DIFF
--- a/script/window/component/content/Content.ts
+++ b/script/window/component/content/Content.ts
@@ -60,7 +60,9 @@ export default class Content extends Component {
 	//
 
 	private async getVolumes () {
-		return (await fs.readdir(options.root)).values()
+		const entries = (await fs.readdir(options.root));
+		entries.sort();
+		return entries.values()
 			.filter(volume => /vol\d\d/.test(volume))
 			.map(async volume => tuple(volume, await this.getChapters(volume)))
 			.awaitAll()
@@ -68,7 +70,9 @@ export default class Content extends Component {
 	}
 
 	private async getChapters (volume: string) {
-		return (await fs.readdir(`${options.root}/${volume}`)).values()
+		const entries = (await fs.readdir(`${options.root}/${volume}`));
+		entries.sort();
+		return entries.values()
 			.filter(chapter => /ch\d\d\d/.test(chapter))
 			.map(async chapter => tuple(chapter, await this.getPages(volume, chapter)))
 			.awaitAll()
@@ -76,7 +80,9 @@ export default class Content extends Component {
 	}
 
 	private async getPages (volume: string, chapter: string) {
-		return (await fs.readdir(`${options.root}/${volume}/${chapter}/raw`)).values()
+		const entries = (await fs.readdir(`${options.root}/${volume}/${chapter}/raw`));
+		entries.sort();
+		return entries.values()
 			.filter(page => /\d\d\d\.png/.test(page))
 			.collect(Collectors.toArray);
 	}


### PR DESCRIPTION
I've just hit this problem after moving to a network drive.
It seems iteration over filesystem entries doesn't have to
follow a specific order, so we'll enforce it ourselves.