### PR TITLE
Trim pasted notes

### DIFF
--- a/script/window/component/content/extractor/Capture.ts
+++ b/script/window/component/content/extractor/Capture.ts
@@ -81,7 +81,7 @@ export default class Capture extends SortableListItem {
 	private async pasteNotes () {
 		const text = await navigator.clipboard.readText();
 		for (const [, note, translation] of (/- (.*?):(.*)/g).matches(text)) {
-			this.addNote([note, translation.trim()]);
+			this.addNote([note.trim(), translation.trim()]);
 		}
 	}
 


### PR DESCRIPTION
Everywhere else, the program eagerly trims input as soon as focus leaves the text area, so this one makes it consistent with the behaviour of the rest of the application.