### PR TITLE
Fix the issue where open/save dialog input config parameters were ignored

### DIFF
--- a/script/window/index.ts
+++ b/script/window/index.ts
@@ -31,7 +31,7 @@ declare global {
 (window as any).send = async (event: WindowEvent, ...args: any[]) => {
 	return new Promise(resolve => {
 		ipcRenderer.once(event, (_: any, result: any) => resolve(result));
-		ipcRenderer.send(event);
+		ipcRenderer.send(event, ...args);
 	});
 };
 


### PR DESCRIPTION
Turns out the event parameters were never sent, which means the `dialog.showSaveDialog` and `dialog.showOpenDialog` were called with `undefined`.