### PR TITLE
Use ImageMagick to downscale images, fall back to the existing downscale procedure when not set

### DIFF
--- a/script/window/data/Thumbs.ts
+++ b/script/window/data/Thumbs.ts
@@ -91,7 +91,9 @@ export default class Thumbs extends Serializable {
 	private async downscaleImageMagickWithFallback (filename: string, targetThumbnailPath: string, scale: number): Promise<boolean> {
 		if (options.imageMagickCLIPath) {
 			const percentage = scale * 100;
-			await ChildProcess.exec(`"${options.imageMagickCLIPath}" -resize ${percentage}% "${Path.join(this.root, filename)}" "${targetThumbnailPath}"`);
+			await concurrent.promise(true, async resolve => {
+				ChildProcess.exec(`"${options.imageMagickCLIPath}" -resize ${percentage}% "${Path.join(this.root, filename)}" "${targetThumbnailPath}"`).then(resolve);
+			})
 			return true;
 		} else {
 			return await this.downscaleIntoThumbnailFile(filename, targetThumbnailPath, scale);


### PR DESCRIPTION
Partially fixes #156 

Ideally we should be making the browser itself do it (because it clearly *can* do it, like, it can display images at a different scale), rather than relying on ImageMagick.