### PR TITLE
fix mac shortcuts

### DIFF
--- a/script/app/init.ts
+++ b/script/app/init.ts
@@ -41,8 +41,9 @@ function createWindow () {
 			contextIsolation: false,
 		},
 	});
-
-	mainWindow.webContents.setIgnoreMenuShortcuts(true);
+	if (process.platform !== "darwin") {
+		mainWindow.webContents.setIgnoreMenuShortcuts(true);
+	}
 	mainWindow.setMenu(null);
 
 	// win.webContents.on("before-input-event", event => event.preventDefault());


### PR DESCRIPTION
fixes #160

Just leaves menu shortcuts enabled if platform is darwin.